### PR TITLE
More aggressive socket closing

### DIFF
--- a/src/main/java/com/microsoft/azure/cassandraproxy/ProxyClient.java
+++ b/src/main/java/com/microsoft/azure/cassandraproxy/ProxyClient.java
@@ -91,7 +91,7 @@ public class ProxyClient  {
         fastDecode.resume();
     }
 
-    public Future<Void> start(Vertx vertx,String host, int port, boolean ssl)
+    public Future<Void> start(Vertx vertx,String host, int port, boolean ssl, int timeout)
     {
         socketPromise = Promise.promise();
         // @TODO: Allow for truststore, etc,
@@ -99,6 +99,8 @@ public class ProxyClient  {
         if (ssl) {
             options.setSsl(true).setTrustAll(true);
         }
+        options.setIdleTimeout(timeout);
+        options.setIdleTimeoutUnit(TimeUnit.SECONDS);
         vertx.createNetClient(options).connect(port, host, res-> {
             if (res.succeeded()) {
                 LOG.info("Server connected");


### PR DESCRIPTION
Closes the sockets when there is an exception on the socket
Closes the server socket as well, when close is called
Implements idle timeout on the client sockets

## Purpose
We noticed after a test like:
` parallel -j 1000 -N0 cqlsh ::: {1..1000}` that some sockets where still hanging around after the test
That's why we improved the closing of sockets and added the timeout on the client sockets.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->